### PR TITLE
Updates `license` key in `composer.json` to match `LICENSE` file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8"
     },
-    "license": "Apache 2.0",
+    "license": "MIT",
     "authors": [
         {
             "name": "Davey Shafik",


### PR DESCRIPTION
This should hopefully be an easy PR to accept.

Issue #1 pointed out that, although the project is listed as being licensed under MIT, the `composer.json` file actually specifies that it's licensed under Apache 2.0.

This PR brings the two licenses back in sync by changing `composer.json` to specify MIT as well.

Alternatively, if the project is supposed to be under Apache 2.0, I can update this PR to move in the other direction and fix the `LICENSE` file instead.
