### PR TITLE
Enable reading and saving of binary responses

### DIFF
--- a/src/VcrHandler.php
+++ b/src/VcrHandler.php
@@ -27,7 +27,7 @@ class VcrHandler
             $handler->after('allow_redirects', new static($cassette));
             return $handler;
         } else {
-            $responses = json_decode(file_get_contents($cassette), true);
+            $responses = json_decode(utf8_decode(file_get_contents($cassette)), true);
 
             $queue = [];
             $class = new \ReflectionClass(\GuzzleHttp\Psr7\Response::class);
@@ -68,7 +68,7 @@ class VcrHandler
                     $responses[] = [
                         'status' =>  $cassette->getStatusCode(),
                         'headers' => $cassette->getHeaders(),
-                        'body' => (string) $cassette->getBody(),
+                        'body' => utf8_encode((string)$cassette->getBody()),
                         'version' => $cassette->getProtocolVersion(),
                         'reason' => $cassette->getReasonPhrase()
                     ];

--- a/src/VcrHandler.php
+++ b/src/VcrHandler.php
@@ -27,7 +27,7 @@ class VcrHandler
             $handler->after('allow_redirects', new static($cassette));
             return $handler;
         } else {
-            $responses = json_decode(utf8_decode(file_get_contents($cassette)), true);
+            $responses = self::decodeResponses($cassette);
 
             $queue = [];
             $class = new \ReflectionClass(\GuzzleHttp\Psr7\Response::class);
@@ -50,6 +50,23 @@ class VcrHandler
     }
 
     /**
+     * Decodes every responses body from base64
+     *
+     * @param $cassette
+     * @return array
+     */
+    protected static function decodeResponses($cassette)
+    {
+        $responses = json_decode(file_get_contents($cassette), true);
+
+        array_walk($responses, function(&$response){
+            $response['body'] = base64_decode($response['body']);
+        });
+
+        return $responses;
+    }
+
+    /**
      * Handle the request/response
      *
      * @param callable $handler
@@ -62,13 +79,14 @@ class VcrHandler
                 function (\Psr\Http\Message\ResponseInterface $response) use ($request) {
                     $responses = [];
                     if (file_exists($this->cassette)) {
+                        //No need to base64 decode body of response here.
                         $responses = json_decode(file_get_contents($this->cassette), true);
                     }
                     $cassette = $response->withAddedHeader('X-VCR-Recording', time());
                     $responses[] = [
                         'status' =>  $cassette->getStatusCode(),
                         'headers' => $cassette->getHeaders(),
-                        'body' => utf8_encode((string)$cassette->getBody()),
+                        'body' => base64_encode((string) $cassette->getBody()),
                         'version' => $cassette->getProtocolVersion(),
                         'reason' => $cassette->getReasonPhrase()
                     ];

--- a/tests/fixtures/test-existing.json
+++ b/tests/fixtures/test-existing.json
@@ -15,7 +15,7 @@
                 "1440121471"
             ]
         },
-        "body": "Hello World",
+        "body": "SGVsbG8gV29ybGQ=",
         "version": "1.1",
         "reason": "OK"
     }


### PR DESCRIPTION
Wonderful package! Thanks very much.

When using it recently I had need to check that my webservice was returning a very small binary file (pdf around 10KB). I notice that no matter how often I tried, the VCR would not record the response and so playback was also broken.

A look in the code shows that the http response body was only being json_encoded. This throws an error when there is non-ascii /binary data in the response. By converting the string to a UTF-8 string, json_encode now works and so all the responses get recorded properly.

Hope it helps.