### PR TITLE
Push VCR recorder onto the Guzzle stack

### DIFF
--- a/src/VcrHandler.php
+++ b/src/VcrHandler.php
@@ -24,7 +24,7 @@ class VcrHandler
     {
         if (!file_exists($cassette)) {
             $handler = \GuzzleHttp\HandlerStack::create();
-            $handler->push(new static($cassette), 'vcr_recorder');
+            $handler->after('allow_redirects', new static($cassette), 'vcr_recorder');
             return $handler;
         } else {
             $responses = json_decode(file_get_contents($cassette), true);

--- a/src/VcrHandler.php
+++ b/src/VcrHandler.php
@@ -24,7 +24,7 @@ class VcrHandler
     {
         if (!file_exists($cassette)) {
             $handler = \GuzzleHttp\HandlerStack::create();
-            $handler->after('allow_redirects', new static($cassette));
+            $handler->push(new static($cassette), 'vcr_recorder');
             return $handler;
         } else {
             $responses = json_decode(file_get_contents($cassette), true);


### PR DESCRIPTION
The previous version was looking for the name of another Guzzle middleware layer on the stack before adding the recorder after it.

The problem with this is that if a user provides their own Stack that didn't have the `allows_redirect` middleware in it, then the VCR recorder would never get added to the stack.
This PR just PUSHES the VCR recorder to the stack and doesn't require another layer to be their first.